### PR TITLE
Refactor and optimize containerfiles

### DIFF
--- a/base/Containerfile
+++ b/base/Containerfile
@@ -7,33 +7,47 @@ COPY usr/ /usr/
 # workaround (see https://github.com/ublue-os/bluefin-lts/issues/3)
 RUN mkdir -p /var/roothome
 
-RUN dnf -y install 'dnf5-command(copr)' && \
-    dnf -y install \
-        @core \
-        @hardware-support \
-        @standard \
-        @base-graphical \
-        --exclude dracut-config-rescue && \
-    dnf -y install \
-        NetworkManager-tui \
-        fedora-release-ostree-desktop \
-        fedora-release-mobility \
-        systemd-oomd-defaults \
-        systemd-resolved \
-        grub2-efi-aa64-modules \
-        grub2-efi-aa64 \
-        glibc-langpack-en \
-        udisks2-btrfs \
-        btrfs-progs \
-        tqftpserv \
-        pd-mapper \
-        grubby \
-        rmtfs \
-        qrtr \
-        fuse \
-        git \
-        vim && \
-    systemctl enable tqftpserv.service && \
-    systemctl enable rmtfs.service && \
-    dnf clean all && \
-    bootc container lint
+RUN dnf -y install 'dnf5-command(copr)'
+
+# base groups
+RUN dnf -y install \
+    @core \
+    @hardware-support \
+    @standard \
+    @base-graphical \
+    --exclude dracut-config-rescue
+
+RUN dnf -y install \
+    fedora-release-ostree-desktop \
+    fedora-release-mobility \
+    systemd-oomd-defaults \
+    systemd-resolved \
+    grub2-efi-aa64-modules \
+    grub2-efi-aa64 \
+    glibc-langpack-en \
+    udisks2-btrfs \
+    btrfs-progs \
+    fuse
+
+# qualcomm
+RUN dnf -y install \
+    tqftpserv \
+    pd-mapper \
+    rmtfs \
+    qrtr
+
+# utils
+RUN dnf -y install \
+    NetworkManager-tui \
+    git \
+    grubby \
+    vim
+
+RUN systemctl enable \
+    tqftpserv.service \
+    rmtfs.service
+
+# clenup
+RUN rm -rf /var/log/* && dnf clean all
+
+RUN bootc container lint

--- a/desktops/gnome-desktop/Containerfile
+++ b/desktops/gnome-desktop/Containerfile
@@ -2,34 +2,39 @@ ARG from
 FROM $from
 
 RUN dnf -y install \
-        @gnome-desktop \
-        gnome-software-rpm-ostree \
-        fedora-release-silverblue \
-        default-flatpaks \
-        --exclude gnome-boxes \
-        --exclude gnome-connections \
-        --exclude gnome-text-editor \
-        --exclude yelp \
-        --exclude baobab \
-        --exclude evince \
-        --exclude evince-djvu \
-        --exclude gnome-calculator \
-        --exclude gnome-calendar \
-        --exclude gnome-characters \
-        --exclude gnome-classic-session \
-        --exclude gnome-clocks \
-        --exclude gnome-contacts \
-        --exclude gnome-font-viewer \
-        --exclude gnome-logs \
-        --exclude gnome-maps \
-        --exclude gnome-system-monitor \
-        --exclude gnome-user-docs \
-        --exclude gnome-weather \
-        --exclude totem \
-        --exclude loupe \
-        --exclude simple-scan \
-        --exclude snapshot \
-        --exclude gnome-tour \
-        --exclude malcontent-control && \
-    systemctl enable gdm.service && \
-    dnf clean all
+    @gnome-desktop \
+    gnome-software-rpm-ostree \
+    fedora-release-silverblue \
+    default-flatpaks \
+    --exclude gnome-boxes \
+    --exclude gnome-connections \
+    --exclude gnome-text-editor \
+    --exclude yelp \
+    --exclude baobab \
+    --exclude evince \
+    --exclude evince-djvu \
+    --exclude gnome-calculator \
+    --exclude gnome-calendar \
+    --exclude gnome-characters \
+    --exclude gnome-classic-session \
+    --exclude gnome-clocks \
+    --exclude gnome-contacts \
+    --exclude gnome-font-viewer \
+    --exclude gnome-logs \
+    --exclude gnome-maps \
+    --exclude gnome-system-monitor \
+    --exclude gnome-user-docs \
+    --exclude gnome-weather \
+    --exclude totem \
+    --exclude loupe \
+    --exclude simple-scan \
+    --exclude snapshot \
+    --exclude gnome-tour \
+    --exclude malcontent-control
+
+RUN systemctl enable gdm.service
+
+# clenup
+RUN rm -rf /var/log/* && dnf clean all
+
+RUN bootc container lint

--- a/desktops/gnome-mobile/Containerfile
+++ b/desktops/gnome-mobile/Containerfile
@@ -4,35 +4,40 @@ FROM $from
 COPY etc/ /etc/
 
 RUN dnf -y install \
-        @gnome-desktop \
-        gnome-shell \
-        gnome-shell-extension-nekotorch \
-        gnome-software-rpm-ostree \
-        default-flatpaks \
-        --exclude gnome-boxes \
-        --exclude gnome-connections \
-        --exclude gnome-text-editor \
-        --exclude yelp \
-        --exclude baobab \
-        --exclude evince \
-        --exclude evince-djvu \
-        --exclude gnome-calculator \
-        --exclude gnome-calendar \
-        --exclude gnome-characters \
-        --exclude gnome-classic-session \
-        --exclude gnome-clocks \
-        --exclude gnome-contacts \
-        --exclude gnome-font-viewer \
-        --exclude gnome-logs \
-        --exclude gnome-maps \
-        --exclude gnome-system-monitor \
-        --exclude gnome-user-docs \
-        --exclude gnome-weather \
-        --exclude totem \
-        --exclude loupe \
-        --exclude simple-scan \
-        --exclude snapshot \
-        --exclude gnome-tour \
-        --exclude malcontent-control && \
-    systemctl enable gdm.service && \
-    dnf clean all
+    @gnome-desktop \
+    gnome-shell \
+    gnome-shell-extension-nekotorch \
+    gnome-software-rpm-ostree \
+    default-flatpaks \
+    --exclude gnome-boxes \
+    --exclude gnome-connections \
+    --exclude gnome-text-editor \
+    --exclude yelp \
+    --exclude baobab \
+    --exclude evince \
+    --exclude evince-djvu \
+    --exclude gnome-calculator \
+    --exclude gnome-calendar \
+    --exclude gnome-characters \
+    --exclude gnome-classic-session \
+    --exclude gnome-clocks \
+    --exclude gnome-contacts \
+    --exclude gnome-font-viewer \
+    --exclude gnome-logs \
+    --exclude gnome-maps \
+    --exclude gnome-system-monitor \
+    --exclude gnome-user-docs \
+    --exclude gnome-weather \
+    --exclude totem \
+    --exclude loupe \
+    --exclude simple-scan \
+    --exclude snapshot \
+    --exclude gnome-tour \
+    --exclude malcontent-control
+
+RUN systemctl enable gdm.service
+
+# clenup
+RUN rm -rf /var/log/* && dnf clean all
+
+RUN bootc container lint

--- a/desktops/phosh/Containerfile
+++ b/desktops/phosh/Containerfile
@@ -1,12 +1,16 @@
 ARG from
 FROM $from
 
-RUN dnf -y install 'dnf5-command(copr)' && \
-    dnf -y copr enable samcday/phrog && \
+RUN dnf -y copr enable samcday/phrog && \
     dnf -y install \
         @phosh-desktop \
         phrog \
         gnome-software-rpm-ostree \
-        default-flatpaks && \
-    systemctl enable --force phrog.service && \
-    dnf clean all
+        default-flatpaks
+
+RUN systemctl enable --force phrog.service
+
+# clenup
+RUN rm -rf /var/log/* && dnf clean all
+
+RUN bootc container lint

--- a/desktops/phosh/Containerfile
+++ b/desktops/phosh/Containerfile
@@ -1,12 +1,13 @@
 ARG from
 FROM $from
 
-RUN dnf -y copr enable samcday/phrog && \
-    dnf -y install \
-        @phosh-desktop \
-        phrog \
-        gnome-software-rpm-ostree \
-        default-flatpaks
+COPY etc/ /etc/
+
+RUN dnf -y install \
+    @phosh-desktop \
+    phrog \
+    gnome-software-rpm-ostree \
+    default-flatpaks
 
 RUN systemctl enable --force phrog.service
 

--- a/desktops/phosh/etc/yum.repos.d/phrog.repo
+++ b/desktops/phosh/etc/yum.repos.d/phrog.repo
@@ -1,0 +1,10 @@
+[copr:copr.fedorainfracloud.org:samcday:phrog]
+name=Copr repo for phrog owned by samcday
+baseurl=https://download.copr.fedorainfracloud.org/results/samcday/phrog/fedora-$releasever-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/samcday/phrog/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1

--- a/desktops/plasma-desktop/Containerfile
+++ b/desktops/plasma-desktop/Containerfile
@@ -2,30 +2,35 @@ ARG from
 FROM $from
 
 RUN dnf -y install \
-        @kde-desktop \
-        fedora-release-kinoite \
-        plasma-discover-rpm-ostree \
-        NetworkManager-wifi \
-        --exclude kernel-* \
-        --exclude=plasma-nm-l2tp \
-        --exclude=NetworkManager-l2tp \
-        --exclude=xl2tpd \
-        --exclude glibc-all-langpacks \
-        --exclude ark \
-        --exclude filelight \
-        --exclude kcharselect \
-        --exclude kdebugsettings \
-        --exclude khelpcenter \
-        --exclude kinfocenter \
-        --exclude kwrite \
-        --exclude plasma-systemmonitor \
-        --exclude akonadi-server \
-        --exclude akonadi-server-mysql \
-        --exclude colord-kde \
-        --exclude cups-pk-helper \
-        --exclude plasma-print-manager \
-        --exclude kde-connect \
-        --exclude plasma-workspace-wallpapers \
-        --exclude plasma-desktop-doc && \
-    systemctl enable sddm.service && \
-    dnf clean all
+    @kde-desktop \
+    fedora-release-kinoite \
+    plasma-discover-rpm-ostree \
+    NetworkManager-wifi \
+    --exclude kernel-* \
+    --exclude=plasma-nm-l2tp \
+    --exclude=NetworkManager-l2tp \
+    --exclude=xl2tpd \
+    --exclude glibc-all-langpacks \
+    --exclude ark \
+    --exclude filelight \
+    --exclude kcharselect \
+    --exclude kdebugsettings \
+    --exclude khelpcenter \
+    --exclude kinfocenter \
+    --exclude kwrite \
+    --exclude plasma-systemmonitor \
+    --exclude akonadi-server \
+    --exclude akonadi-server-mysql \
+    --exclude colord-kde \
+    --exclude cups-pk-helper \
+    --exclude plasma-print-manager \
+    --exclude kde-connect \
+    --exclude plasma-workspace-wallpapers \
+    --exclude plasma-desktop-doc
+
+RUN systemctl enable sddm.service
+
+# clenup
+RUN rm -rf /var/log/* && dnf clean all
+
+RUN bootc container lint

--- a/desktops/plasma-mobile/Containerfile
+++ b/desktops/plasma-mobile/Containerfile
@@ -2,33 +2,38 @@ ARG from
 FROM $from
 
 RUN dnf -y install \
-        @kde-mobile-environment \
-        plasma-discover-rpm-ostree \
-        NetworkManager-wifi \
-        --exclude ark \
-        --exclude filelight \
-        --exclude kcharselect \
-        --exclude kdebugsettings \
-        --exclude khelpcenter \
-        --exclude kinfocenter \
-        --exclude kwrite \
-        --exclude plasma-systemmonitor \
-        --exclude angelfish \
-        --exclude arianna \
-        --exclude elisa-player \
-        --exclude haruna \
-        --exclude kalk \
-        --exclude kasts \
-        --exclude kclock \
-        --exclude keysmith \
-        --exclude koko \
-        --exclude krecorder \
-        --exclude kweather \
-        --exclude marknote \
-        --exclude neochat \
-        --exclude okular-mobile \
-        --exclude qrca \
-        --exclude spacebar \
-        --exclude tokodon && \
-    systemctl enable sddm.service && \
-    dnf clean all
+    @kde-mobile-environment \
+    plasma-discover-rpm-ostree \
+    NetworkManager-wifi \
+    --exclude ark \
+    --exclude filelight \
+    --exclude kcharselect \
+    --exclude kdebugsettings \
+    --exclude khelpcenter \
+    --exclude kinfocenter \
+    --exclude kwrite \
+    --exclude plasma-systemmonitor \
+    --exclude angelfish \
+    --exclude arianna \
+    --exclude elisa-player \
+    --exclude haruna \
+    --exclude kalk \
+    --exclude kasts \
+    --exclude kclock \
+    --exclude keysmith \
+    --exclude koko \
+    --exclude krecorder \
+    --exclude kweather \
+    --exclude marknote \
+    --exclude neochat \
+    --exclude okular-mobile \
+    --exclude qrca \
+    --exclude spacebar \
+    --exclude tokodon
+
+RUN systemctl enable sddm.service
+
+# clenup
+RUN rm -rf /var/log/* && dnf clean all
+
+RUN bootc container lint

--- a/devices/mipad5/Containerfile
+++ b/devices/mipad5/Containerfile
@@ -4,17 +4,24 @@ FROM $from
 COPY etc/ /etc/
 COPY usr/ /usr/
 
+# kernel
 RUN mkdir -p /boot/dtb && \
     dnf -y remove \
         kernel \
         kernel-core \
         kernel-modules \
         kernel-modules-core && \
-    dnf -y install \
-        kernel \
-        xiaomi-nabu-firmware \
-        xiaomi-nabu-audio \
-        qbootctl && \
-    systemctl enable qbootctl.service && \
-    dnf clean all && \
-    bootc container lint
+    dnf -y install kernel && \
+    rm -r /boot/dtb
+
+RUN dnf -y install \
+    xiaomi-nabu-firmware \
+    xiaomi-nabu-audio \
+    qbootctl
+
+RUN systemctl enable qbootctl.service
+
+# clenup
+RUN rm -rf /var/log/* && dnf clean all
+
+RUN bootc container lint

--- a/devices/oneplus6/Containerfile
+++ b/devices/oneplus6/Containerfile
@@ -4,33 +4,48 @@ FROM $from
 COPY etc/ /etc/
 COPY usr/ /usr/
 
+# kernel
 RUN mkdir /boot/dtb && \
     dnf -y remove kernel && \
-    dnf -y install \
-        kernel \
-        kernel-modules-extra && \
-    dnf -y install \
-        alsa-utils \
-        pipewire \
-        pipewire-alsa \
-        pipewire-pulseaudio \
-        alsa-ucm-mobility-sdm845 \
-        bcm283x-firmware \
-        mobility-tweaks \
-        qcom-firmware \
-        pil-squasher \
-        buffyboard \
-        hexagonrpc \
-        qbootctl \
-        bootmac \
-        libssc && \
-    systemctl enable qbootctl.service && \
-    systemctl enable bootmac-bluetooth.service && \
-    systemctl enable hexagonrpcd-sdsp.service && \
-    systemctl enable msm-modem-uim-selection.service && \
-    systemctl disable bootc-fetch-apply-updates.timer && \
-    dnf clean all
+    dnf -y install kernel kernel-modules-extra && \
+    rm -rf /boot/dtb
+
+# firmware
+RUN dnf -y install \
+    bcm283x-firmware \
+    qcom-firmware
+
+# qualcomm tools and libs
+RUN dnf -y install \
+    libssc \
+    hexagonrpc \
+    pil-squasher \
+    qbootctl \
+    bootmac
+
+# audio
+RUN dnf -y install \
+    alsa-utils \
+    pipewire \
+    pipewire-alsa \
+    pipewire-pulseaudio \
+    alsa-ucm-mobility-sdm845
+
+# other
+RUN dnf -y install \
+    mobility-tweaks \
+    buffyboard
+
+RUN systemctl enable \
+    qbootctl.service \
+    bootmac-bluetooth.service \
+    hexagonrpcd-sdsp.service \
+    msm-modem-uim-selection.service
+RUN systemctl disable bootc-fetch-apply-updates.timer
 
 COPY fwload/usr/ /usr/
+
+# clenup
+RUN rm -rf /var/log/* && dnf clean all
 
 RUN bootc container lint


### PR DESCRIPTION
- divide package installation commands into different RUN sections (we don't really care about the number of layers, we're going to implement rechunking later anyway)
- remove `/boot/dtb` - it is only required to fix a kernel replacement problem
- clean `/var/log`
- run `bootc container lint`  inside every container to detect potential issues
- add the `samcday/phrog` copr using yum.repos.d