### PR TITLE
mipad6: fix bluetooth and regenerate initramfs to include novatek firmwares

### DIFF
--- a/devices/mipad6/Containerfile
+++ b/devices/mipad6/Containerfile
@@ -20,7 +20,7 @@ RUN dnf -y install \
     pipa-sound-conf \
     bootmac
 
-RUN systemctl enable qbootctl.service
+RUN systemctl enable qbootctl.service bootmac-bluetooth
 
 # cleanup
 RUN rm -rf /var/log/* && dnf clean all

--- a/devices/mipad6/Containerfile
+++ b/devices/mipad6/Containerfile
@@ -20,6 +20,9 @@ RUN dnf -y install \
     pipa-sound-conf \
     bootmac
 
+RUN kver=$(rpm -q --qf '%{VERSION}-%{RELEASE}' kernel) && \
+    dracut -vf --kver $kver -o /usr/lib/modules/$kver/initramfs.img
+
 RUN systemctl enable qbootctl.service bootmac-bluetooth
 
 # cleanup


### PR DESCRIPTION
- Enable bootmac-bluetooth service
- Regerate initramfs after installing firmwares