### PR TITLE
Add a device.conf option to install dtb to esp

### DIFF
--- a/.github/workflows/helper-build-image.yml
+++ b/.github/workflows/helper-build-image.yml
@@ -42,6 +42,7 @@ jobs:
         config_file: ./config.toml
         esp_size: ${{ steps.conf.outputs.esp_size }}
         rootfs: ${{ inputs.rootfs }}
+        install_dtb: ${{ steps.conf.outputs.install_dtb }}
         registry: ${{ vars.REGISTRY }}
         image_name: ${{ inputs.image_name }}
         image_tag: ${{ inputs.image_tag }}

--- a/devices/mipad5/device.conf
+++ b/devices/mipad5/device.conf
@@ -1,1 +1,2 @@
 esp_size=536870912
+install_dtb=false

--- a/devices/mipad6/device.conf
+++ b/devices/mipad6/device.conf
@@ -1,1 +1,2 @@
 esp_size=536870912
+install_dtb=false

--- a/devices/oneplus6/device.conf
+++ b/devices/oneplus6/device.conf
@@ -1,1 +1,2 @@
 esp_size=268435456
+install_dtb=true

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -9,6 +9,7 @@ that will help you contribute to Pocketblue
 - [Technical details](#technical-details)
   - [Build process](#build-process)
   - [Repository layout](#repository-layout)
+    - [device.conf](#deviceconf)
 - [Contribution guide](#contribution-guide)
   - [Adding a new device](#adding-a-new-device)
   - [Building using Github Actions in a forked repo](#building-using-github-actions-in-a-forked-repo)
@@ -34,7 +35,7 @@ Flashable disk images are built using bootc-image-builder by the images.yml work
 
 - `base/` - base image recipe and files
 - `devices/<device-name>/` - device images
-  - `devices/<device-name>/device.conf` - various device configuration options, see [device.conf](#device-conf)
+  - `devices/<device-name>/device.conf` - various device configuration options, see [device.conf](#deviceconf)
 - `desktops/<desktop-name>/` - desktop images
 - `scripts/` - various scripts for building and flashing disk images
 - `docs/` - documentation

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,11 +34,16 @@ Flashable disk images are built using bootc-image-builder by the images.yml work
 
 - `base/` - base image recipe and files
 - `devices/<device-name>/` - device images
-  - `devices/<device-name>/device.conf` - currently only contains one parameter - ESP size in bytes used when building disk images
+  - `devices/<device-name>/device.conf` - various device configuration options, see [device.conf](#device-conf)
 - `desktops/<desktop-name>/` - desktop images
 - `scripts/` - various scripts for building and flashing disk images
 - `docs/` - documentation
 - `config.toml` - bootc-image-builder config
+
+#### device.conf
+
+- `esp_size` - ESP size in bytes
+- `install_dtb` - boolean, whether to install device trees to ESP
 
 ## Contribution guide
 


### PR DESCRIPTION
This will allow u-boot to use up-to-date device trees packaged with the kernel, resolving #17