### PR TITLE
Temporary (?) fix for some dirs in /var being removed by the rechunker

### DIFF
--- a/base/usr/lib/tmpfiles.d/rechunk-fix.conf
+++ b/base/usr/lib/tmpfiles.d/rechunk-fix.conf
@@ -1,0 +1,3 @@
+d /var/spool/at 700 root root - -
+d /var/account 755 root root - -
+d /var/lib/plocate 755 root root - -


### PR DESCRIPTION
Until it's fixed on the rechunker side or there's a better solution