### PR TITLE
Make /usr/local and /opt mutable

### DIFF
--- a/base/Containerfile
+++ b/base/Containerfile
@@ -8,8 +8,8 @@ COPY usr/ /usr/
 RUN mkdir -p /var/roothome
 
 # make /usr/local and /opt directories mutable
-RUN rmdir /usr/local && \
-    rmdir /opt && \
+RUN rm -rf /usr/local && \
+    rm -rf /opt && \
     ln -s /var/usrlocal /usr/local && \
     ln -s /var/opt /opt
 


### PR DESCRIPTION
By default bootc makes /usr/local and /opt a part of the system image, allowing derived images to install files in these directories. Symlink them to /var/... to make them mutable for end users

See: https://bootc-dev.github.io/bootc//filesystem.html#usrlocal