### PR TITLE
Revert removal of some packages from KDE images

### DIFF
--- a/desktops/plasma-desktop/build
+++ b/desktops/plasma-desktop/build
@@ -35,23 +35,4 @@ dnf -y remove \
     google-noto-sans-mono-vf-fonts \
     google-noto-serif-vf-fonts
 
-dnf -y remove \
-    kjournald \
-    kwalletmanager5 \
-    clinfo \
-    freerdp \
-    aha \
-    antiword \
-    bolt \
-    cryfs \
-    gdb \
-    gdb-headless \
-    brltty \
-    open-vm-tools \
-    open-vm-tools-desktop \
-    cldr-emoji-annotation \
-    cldr-emoji-annotation-dtd \
-    ibus-typing-booster \
-    mariadb*
-
 systemctl enable sddm.service

--- a/desktops/plasma-mobile/build
+++ b/desktops/plasma-mobile/build
@@ -43,23 +43,4 @@ dnf -y remove \
     google-noto-sans-mono-vf-fonts \
     google-noto-serif-vf-fonts
 
-dnf -y remove \
-    kjournald \
-    kwalletmanager5 \
-    clinfo \
-    freerdp \
-    aha \
-    antiword \
-    bolt \
-    cryfs \
-    gdb \
-    gdb-headless \
-    brltty \
-    open-vm-tools \
-    open-vm-tools-desktop \
-    cldr-emoji-annotation \
-    cldr-emoji-annotation-dtd \
-    ibus-typing-booster \
-    mariadb*
-
 systemctl enable sddm.service


### PR DESCRIPTION
- ~~Change rechunk semantics in Justfile: no need to specify rechunk_suffix manually, the `rechunk` command will retag the image automatically. Docs: https://github.com/pocketblue/wiki/pull/8~~
- Revert removal of some packages from KDE images