### PR TITLE
Don't enable display manager services (except for phosh)

### DIFF
--- a/desktops/gnome-desktop/build
+++ b/desktops/gnome-desktop/build
@@ -15,5 +15,3 @@ dnf -y remove \
     gnome-tour \
     malcontent-control \
     yelp
-
-systemctl enable gdm.service

--- a/desktops/gnome-mobile/build
+++ b/desktops/gnome-mobile/build
@@ -22,5 +22,3 @@ dnf -y remove \
     gnome-tour \
     malcontent-control \
     yelp
-
-systemctl enable gdm.service

--- a/desktops/plasma-desktop/build
+++ b/desktops/plasma-desktop/build
@@ -34,5 +34,3 @@ dnf -y remove \
     google-noto-serif-fonts \
     google-noto-sans-mono-vf-fonts \
     google-noto-serif-vf-fonts
-
-systemctl enable sddm.service

--- a/desktops/plasma-mobile/build
+++ b/desktops/plasma-mobile/build
@@ -42,5 +42,3 @@ dnf -y remove \
     google-noto-serif-fonts \
     google-noto-sans-mono-vf-fonts \
     google-noto-serif-vf-fonts
-
-systemctl enable sddm.service


### PR DESCRIPTION
They're already enabled in the base images

Fixes #123

Tested here: https://github.com/pocketblue/pocketblue/actions/runs/21102995047