### PR TITLE
Exclude nothing-spacewar from auto builds for the time being

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -80,7 +80,6 @@ jobs:
           vars_registry: ${{ vars.REGISTRY }}
           device: ${{ inputs.device || '' }}
           device_list: |
-            nothing-spacewar
             oneplus-sdm845
             xiaomi-beryllium
             xiaomi-nabu


### PR DESCRIPTION
To save build time. It can be added back in a dedicated branch when it will be worked on again