### PR TITLE
Pull the target image before building containers for better rechunking

### DIFF
--- a/.github/workflows/helper-build-container.yml
+++ b/.github/workflows/helper-build-container.yml
@@ -55,6 +55,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: extractions/setup-just@v3
 
+      - name: Pull
+        id: pull
+        run: |
+          just $JUST_ARGS pull
+
       - name: Build
         id: build
         run: just $JUST_ARGS build --build-arg xiaomi_nabu_samsung_ufs=${{ inputs.xiaomi_nabu_samsung_ufs }}


### PR DESCRIPTION
Works: https://github.com/pocketblue/pocketblue/actions/runs/21564989611/job/62134927269#step:6:9