### PR TITLE
oneplus-sdm845: don't erase op2 partition

### DIFF
--- a/devices/oneplus-sdm845/flash-scripts/flash-oneplus-sdm845.sh.in
+++ b/devices/oneplus-sdm845/flash-scripts/flash-oneplus-sdm845.sh.in
@@ -15,7 +15,6 @@ echo 'waiting for device appear in fastboot'
 fastboot getvar product 2>&1 | grep sdm845
 fastboot erase dtbo_a
 fastboot erase dtbo_b
-fastboot erase op2 2> /dev/null || true
 fastboot flash boot     images/uboot-$device.img --slot=all
 fastboot flash system_a images/fedora_boot.raw
 fastboot flash system_b images/fedora_esp.raw


### PR DESCRIPTION
We haven't flashed ESP into op2 in ages, so no need to erase it anymore
