### PR TITLE
containers.yml: remove push trigger

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -46,14 +46,6 @@ on:
         description: 'ARG: xiaomi_nabu_samsung_ufs'
         required: true
         default: false
-  push:
-    paths:
-      - 'Containerfile'
-      - 'common/**'
-      - 'devices/**'
-      - '!devices/*/build-aux/**'
-      - '!devices/*/flash-scripts/**'
-      - 'desktops/**'
 
 run-name: >
   containers:


### PR DESCRIPTION
Automatic container builds on push have some problems, namely:

1. We have many devices and desktop variants, and they no longer fit into the GH concurrent jobs limit, which slows everything down (and there's no point to rebuild everything)
2. Multiple automatic build can race with each other
3. You may want to push without rebuilding
4. It uses an unnecessary amount of resources
