### PR TITLE
Disable redundant zip archive creation

### DIFF
--- a/.github/workflows/images-release.yml
+++ b/.github/workflows/images-release.yml
@@ -77,11 +77,11 @@ jobs:
         run: |
           du 'pocketblue-${{ matrix.device.name }}-${{ matrix.desktop }}-${{ matrix.device.tag }}.7z' -h
           du 'pocketblue-${{ matrix.device.name }}-${{ matrix.desktop }}-${{ matrix.device.tag }}.7z'
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: pocketblue-${{ matrix.device.name }}-${{ matrix.desktop }}-${{ matrix.device.tag }}
           path: pocketblue-${{ matrix.device.name }}-${{ matrix.desktop }}-${{ matrix.device.tag }}.7z
-          compression-level: 0
+          archive: false
       - uses: svenstaro/upload-release-action@v2
         with:
           release_id: ${{ needs.create_release.outputs.release_id }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -74,14 +74,14 @@ jobs:
           image_name: ${{ inputs.device }}-${{ matrix.desktop }}
           image_tag: ${{ inputs.tag }}
           build_aux: ${{ inputs.device == 'xiaomi-nabu' && inputs.nabu_samsung_ufs && 'build-aux.samsung' || 'build-aux' }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: pocketblue-${{ inputs.device }}-${{ matrix.desktop }}-${{ inputs.tag }}
           path: pocketblue-${{ inputs.device }}-${{ matrix.desktop }}-${{ inputs.tag }}.7z
-          compression-level: 0
-      - uses: actions/upload-artifact@v4
+          archive: false
+      - uses: actions/upload-artifact@v7
         with:
           if-no-files-found: ignore
           name: rootfs-${{ inputs.device }}-${{ matrix.desktop }}-${{ inputs.tag }}
           path: rootfs-${{ inputs.device }}-${{ matrix.desktop }}-${{ inputs.tag }}.ero
-          compression-level: 0
+          archive: false


### PR DESCRIPTION
Don't wrap already compressed .7z artifacts in .zip (added in `actions/upload-artifact@v7`)

Tested in https://github.com/pocketblue/pocketblue/actions/runs/23095827075