### PR TITLE
[TEST] xiaomi-nabu-samsung: test the `fw_devlink=permissive` karg

### DIFF
--- a/devices/xiaomi-nabu/build
+++ b/devices/xiaomi-nabu/build
@@ -8,6 +8,7 @@ cp -arfT files/etc /etc
 
 if [ "$xiaomi_nabu_samsung_ufs" = "true" ]; then
     cp -arfT files/samsung/etc /etc
+    cp -arfT files/samsung/usr /usr
 fi
 
 # Packages

--- a/devices/xiaomi-nabu/files/samsung/usr/lib/bootc/kargs.d/00-fw-devlink-permissive.toml
+++ b/devices/xiaomi-nabu/files/samsung/usr/lib/bootc/kargs.d/00-fw-devlink-permissive.toml
@@ -1,0 +1,1 @@
+kargs = ["fw_devlink=permissive"]


### PR DESCRIPTION
Test the `fw_devlink=permissive` karg

https://github.com/pocketblue/pocketblue/actions/runs/24011004215

Rebase only with `bootc`, not `rpm-ostree`, otherwise it won't pick up the karg:

```bash
sudo rpm-ostree reset
sudo bootc switch quay.io/pocketblue/xiaomi-nabu-gnome-desktop:43-fw-devlink
reboot
```

Alternatively, just add the karg manually:

```bash
sudo rpm-ostree kargs --append='fw_devlink=permissive'
reboot
```