### PR TITLE
actions: bump extractions/setup-just to v4

### DIFF
--- a/.github/workflows/helper-build-container.yml
+++ b/.github/workflows/helper-build-container.yml
@@ -61,7 +61,7 @@ jobs:
           EOF
 
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
         with:
           just-version: '1.46.0'
 


### PR DESCRIPTION
Fixes the rest of the Node version warnings in container builds

Test run: https://github.com/pocketblue/pocketblue/actions/runs/24897181971