### PR TITLE
Use rpm-ostree's rechunker directly, w/o fedora-bootc

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -26,8 +26,6 @@ base := env("PB_BASE",
     }
 )
 
-base_bootc := env("PB_BASE_BOOTC", "quay.io/fedora/fedora-bootc:" + branch)
-
 registry := env("PB_REGISTRY", "localhost")
 
 expires_after := env("PB_EXPIRES_AFTER", "")
@@ -38,7 +36,6 @@ default: build
 
 pull:
     sudo podman pull {{base}}:{{branch}}
-    sudo podman pull {{base_bootc}}
     sudo podman pull {{registry}}/{{device}}-{{desktop}}:{{tag}} || true
 
 build *ARGS:
@@ -56,10 +53,12 @@ build *ARGS:
 
 rechunk *ARGS:
     sudo podman run --rm --privileged -v /var/lib/containers:/var/lib/containers {{ARGS}} \
-        {{base_bootc}} \
-        /usr/libexec/bootc-base-imagectl rechunk \
-        {{registry}}/{{device}}-{{desktop}}:{{tag}}{{rechunk_suffix}} \
-        {{registry}}/{{device}}-{{desktop}}:{{tag}}
+        {{base}}:{{branch}} \
+        rpm-ostree experimental compose build-chunked-oci \
+            --bootc \
+            --format-version=1 \
+            --from={{registry}}/{{device}}-{{desktop}}:{{tag}}{{rechunk_suffix}} \
+            --output=containers-storage:{{registry}}/{{device}}-{{desktop}}:{{tag}}
 
 rebase local_image=(registry / device + "-" + desktop + ":" + tag):
     sudo rpm-ostree rebase ostree-unverified-image:containers-storage:{{local_image}}

--- a/Justfile
+++ b/Justfile
@@ -24,7 +24,7 @@ base := env("PB_BASE",
     } else {
         base_atomic
     }
-)
+) + ":" + branch
 
 registry := env("PB_REGISTRY", "localhost")
 
@@ -35,14 +35,14 @@ arch := env("PB_ARCH", "arm64")
 default: build
 
 pull:
-    sudo podman pull {{base}}:{{branch}}
+    sudo podman pull {{base}}
     sudo podman pull {{registry}}/{{device}}-{{desktop}}:{{tag}} || true
 
 build *ARGS:
     sudo buildah bud \
         --layers=true \
         --arch="{{arch}}" \
-        --build-arg="base={{base}}:{{branch}}" \
+        --build-arg="base={{base}}" \
         --build-arg="device={{device}}" \
         --build-arg="desktop={{desktop}}" \
         --build-arg="target_tag={{tag}}" \
@@ -53,7 +53,7 @@ build *ARGS:
 
 rechunk *ARGS:
     sudo podman run --rm --privileged -v /var/lib/containers:/var/lib/containers {{ARGS}} \
-        {{base}}:{{branch}} \
+        {{base}} \
         rpm-ostree experimental compose build-chunked-oci \
             --bootc \
             --format-version=1 \


### PR DESCRIPTION
That's the only thing we used fedora-bootc images for, so why not just use rpm-ostree directly

Reference: https://gitlab.com/fedora/bootc/base-images/-/blob/440f6c79992e55b4cb3f3c6cdbdb2c2d521e9d9e/bootc-base-imagectl#L156

- First test run: https://github.com/pocketblue/pocketblue/actions/runs/25085259279/job/73499284743#step:7:1
- Second test run: https://github.com/pocketblue/pocketblue/actions/runs/25085633702/job/73500461828#step:7:1