### PR TITLE
preinstall.d

### DIFF
--- a/common/build
+++ b/common/build
@@ -8,6 +8,8 @@ cp -arfT files/usr /usr
 # workaround (see https://github.com/ublue-os/bluefin-lts/issues/3)
 mkdir -p /var/roothome
 
+curl --retry 3 -Lo /etc/flatpak/remotes.d/flathub.flatpakrepo https://dl.flathub.org/repo/flathub.flatpakrepo
+
 # setup development tools
 dnf -y install git just buildah
 systemctl enable sshd.service


### PR DESCRIPTION
Set up Flathub during container image builds using remotes.d

This is needed for https://github.com/pocketblue/packages/pull/36 which implements default Flatpak apps installation via preinstall.d