### PR TITLE
images-release: bump softprops/action-gh-release to v3

### DIFF
--- a/.github/workflows/images-release.yml
+++ b/.github/workflows/images-release.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           export full_version=$(skopeo inspect docker://quay.io/pocketblue/qualcomm-sdm845-phosh:${{ inputs.fedora_branch }} --format '{{ index .Labels "org.opencontainers.image.version" }}')
           echo version=$(echo $full_version | cut -d. -f1-2) >> $GITHUB_OUTPUT
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         id: create_release
         with:
           tag_name: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
Fixes the last Node 20 warning