### PR TITLE
pipa: update kxboot image source, allowing for kernel updates

### DIFF
--- a/devices/xiaomi-pipa/build-aux/extra-sources
+++ b/devices/xiaomi-pipa/build-aux/extra-sources
@@ -1,1 +1,1 @@
-images/kxboot.img https://github.com/timoxa0/kxboot-pipa/releases/download/v1.0.1/kxboot-pipa.img f2b114c8eb5ebef6eed301375b743b47051d5a0e605ecf3e739d3ab0b73a3c1b
+images/kxboot.img https://github.com/rr1111/kxboot-pipa/releases/download/v1.0.1/kxboot-pipa.img f9c333c51bad5daaa808ab85cd59e14849db372fdf3656dbc0ae7e411cbab480


### PR DESCRIPTION
Goodday,

since the only thing preventing kernel updates on pipa is a source string to the kernel rpm in kxboot, i have now [forked](https://github.com/rr1111/kxboot-pipa) the project.
I am willing to maintain it on new kernel updates.

It now ships kernel 6.18.2 from my copr repository instead of the original authors, but it might make sense to change it to pull from yours, if you want. I sadly dont think its possible right now to make it always pull the latest package, since it seems to require a direct link to an rpm.

Its 6.18.2 for now because im still testing 7.0.0 since a user reported audio issues on Fedora Base which I was able to reproduce.

This depends on [this MR in /packages](https://github.com/pocketblue/packages/pull/38).