### PR TITLE
Ubuntu 26.04 runners

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -65,7 +65,7 @@ run-name: >
 
 jobs:
   config:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-26.04-arm
     outputs:
       target_tag: ${{ steps.config.outputs.target_tag }}
       expires: ${{ steps.config.outputs.expires }}
@@ -88,7 +88,7 @@ jobs:
             xunlong-orangepi3-lts
 
   desktops:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-26.04-arm
     outputs:
       desktops: ${{ steps.desktops.outputs.desktops }}
     steps:

--- a/.github/workflows/helper-build-container.yml
+++ b/.github/workflows/helper-build-container.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   build:
     name: ${{ inputs.device }}-${{ inputs.desktop }}
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-26.04-arm
     permissions:
       packages: write
     steps:

--- a/.github/workflows/images-release.yml
+++ b/.github/workflows/images-release.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   create_release:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-26.04-arm
     name: create release
     outputs:
       release_id: ${{ steps.create_release.outputs.id }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -56,7 +56,7 @@ on:
 
 jobs:
   desktops:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-26.04-arm
     outputs:
       desktops: ${{ steps.desktops.outputs.desktops }}
     steps:
@@ -74,7 +74,7 @@ jobs:
 
   images:
     needs: desktops
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-26.04-arm
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Use Ubuntu 26.04 runners. They have updated podman so we don't need to update it with brew anymore (https://github.com/pocketblue/actions/pull/19)