### PR TITLE
Rechunk to 127 (+1) layers

### DIFF
--- a/tools/containers.just
+++ b/tools/containers.just
@@ -21,6 +21,7 @@ rechunk *ARGS:
         rpm-ostree experimental compose build-chunked-oci \
             --bootc \
             --format-version=1 \
+            --max-layers=127 \
             --from={{full_image}}{{rechunk_suffix}} \
             --output=containers-storage:{{full_image}}
 


### PR DESCRIPTION
Use `--max-layers=127` when rechunking to decrease update size. Rechunker adds one more layer resulting in a total of 128 layers (as opposed to the default of 65)