### PR TITLE
Use rpm-ostree instead of dnf to debloat the image

### DIFF
--- a/common/build
+++ b/common/build
@@ -21,6 +21,4 @@ systemctl enable usb-network.service
 # only keep the EN langpack to decrease image size
 dnf -y swap glibc-all-langpacks glibc-langpack-en
 
-dnf -y remove dracut-config-rescue
-
-dnf -y remove nvidia-gpu-firmware
+rpm-ostree override remove nvidia-gpu-firmware

--- a/desktops/gnome-desktop/build
+++ b/desktops/gnome-desktop/build
@@ -4,11 +4,11 @@ set -uexo pipefail
 
 dnf -y install default-flatpaks
 
-dnf -y remove \
+rpm-ostree override remove \
     firefox \
     firefox-langpacks
 
-dnf -y remove \
+rpm-ostree override remove \
     gnome-classic-session \
     gnome-system-monitor \
     gnome-user-docs \

--- a/desktops/gnome-mobile/build
+++ b/desktops/gnome-mobile/build
@@ -11,11 +11,11 @@ dnf -y install \
     default-flatpaks\
     gnome-shell-extension-nekotorch
 
-dnf -y remove \
+rpm-ostree override remove \
     firefox \
     firefox-langpacks
 
-dnf -y remove \
+rpm-ostree override remove \
     gnome-classic-session \
     gnome-system-monitor \
     gnome-user-docs \

--- a/desktops/gnome-mobile/build
+++ b/desktops/gnome-mobile/build
@@ -8,7 +8,7 @@ dnf -y remove gnome-shell mutter gnome-settings-daemon
 dnf -y install gnome-shell mutter gnome-settings-daemon
 
 dnf -y install \
-    default-flatpaks\
+    default-flatpaks \
     gnome-shell-extension-nekotorch
 
 rpm-ostree override remove \
@@ -16,7 +16,6 @@ rpm-ostree override remove \
     firefox-langpacks
 
 rpm-ostree override remove \
-    gnome-classic-session \
     gnome-system-monitor \
     gnome-user-docs \
     gnome-tour \

--- a/desktops/phosh/build
+++ b/desktops/phosh/build
@@ -12,7 +12,6 @@ rpm-ostree override remove \
     firefox-langpacks
 
 rpm-ostree override remove \
-    gnome-classic-session \
     gnome-system-monitor \
     gnome-user-docs \
     gnome-tour \

--- a/desktops/phosh/build
+++ b/desktops/phosh/build
@@ -7,11 +7,11 @@ dnf -y install phosh phrog
 
 dnf -y install default-flatpaks
 
-dnf -y remove \
+rpm-ostree override remove \
     firefox \
     firefox-langpacks
 
-dnf -y remove \
+rpm-ostree override remove \
     gnome-classic-session \
     gnome-system-monitor \
     gnome-user-docs \

--- a/desktops/plasma-desktop/build
+++ b/desktops/plasma-desktop/build
@@ -4,11 +4,11 @@ set -uexo pipefail
 
 dnf -y install default-flatpaks
 
-dnf -y remove \
+rpm-ostree override remove \
     firefox \
     firefox-langpacks
 
-dnf -y remove \
+rpm-ostree override remove \
     ark \
     filelight \
     kcharselect \

--- a/desktops/plasma-desktop/build
+++ b/desktops/plasma-desktop/build
@@ -9,28 +9,62 @@ rpm-ostree override remove \
     firefox-langpacks
 
 rpm-ostree override remove \
+    akonadi-server \
+    akonadi-server-mysql \
     ark \
+    ark-libs \
+    bluez-cups \
+    braille-printer-app \
+    c2esp \
+    colord-kde \
+    cups \
+    cups-browsed \
+    cups-filters \
+    cups-filters-driverless \
+    default-fonts-core-mono \
+    default-fonts-core-serif \
+    default-fonts-other-mono \
+    default-fonts-other-serif \
+    dymo-cups-drivers \
     filelight \
+    ghostscript \
+    ghostscript-tools-fontutils \
+    ghostscript-tools-printing \
+    google-droid-sans-fonts \
+    google-noto-sans-mono-vf-fonts \
+    google-noto-serif-fonts \
+    google-noto-serif-vf-fonts \
+    gutenprint-cups \
+    hplip \
+    ImageMagick \
+    ImageMagick-libs \
     kcharselect \
     kdebugsettings \
     kde-connect \
+    kdeconnectd \
+    kde-connect-libs \
     khelpcenter \
     kinfocenter \
     kwrite \
-    plasma-systemmonitor \
-    akonadi-server \
-    akonadi-server-mysql \
-    colord-kde \
-    plasma-print-manager \
-    plasma-workspace-wallpapers \
-    plasma-desktop-doc \
-    phonon-qt6-backend-vlc \
-    vlc-libs \
-    vlc-plugins-base \
-    vlc-plugin-pulseaudio \
-    vlc-plugin-gstreamer \
+    langpacks-en \
+    langpacks-fonts-en \
+    libcupsfilters \
+    libgs \
+    libppd \
     phonon-backend-vlc-common \
-    google-droid-sans-fonts \
-    google-noto-serif-fonts \
-    google-noto-sans-mono-vf-fonts \
-    google-noto-serif-vf-fonts
+    phonon-qt6-backend-vlc \
+    plasma-desktop-doc \
+    plasma-print-manager \
+    plasma-print-manager-libs \
+    plasma-systemmonitor \
+    plasma-workspace-wallpapers \
+    printer-driver-brlaser \
+    ptouch-driver \
+    splix \
+    vlc-libs \
+    vlc-plugin-ffmpeg \
+    vlc-plugin-gstreamer \
+    vlc-plugin-pipewire \
+    vlc-plugin-pulseaudio \
+    vlc-plugins-base \
+    vlc-plugins-video-out

--- a/desktops/plasma-mobile/build
+++ b/desktops/plasma-mobile/build
@@ -11,11 +11,11 @@ dnf -y install \
 
 dnf -y install default-flatpaks
 
-dnf -y remove \
+rpm-ostree override remove \
     firefox \
     firefox-langpacks
 
-dnf -y remove \
+rpm-ostree override remove \
     ark \
     filelight \
     kcharselect \

--- a/desktops/plasma-mobile/build
+++ b/desktops/plasma-mobile/build
@@ -16,29 +16,62 @@ rpm-ostree override remove \
     firefox-langpacks
 
 rpm-ostree override remove \
+    akonadi-server \
+    akonadi-server-mysql \
     ark \
+    ark-libs \
+    bluez-cups \
+    braille-printer-app \
+    c2esp \
+    colord-kde \
+    cups \
+    cups-browsed \
+    cups-filters \
+    cups-filters-driverless \
+    default-fonts-core-mono \
+    default-fonts-core-serif \
+    default-fonts-other-mono \
+    default-fonts-other-serif \
+    dymo-cups-drivers \
     filelight \
+    ghostscript \
+    ghostscript-tools-fontutils \
+    ghostscript-tools-printing \
+    google-droid-sans-fonts \
+    google-noto-sans-mono-vf-fonts \
+    google-noto-serif-fonts \
+    google-noto-serif-vf-fonts \
+    gutenprint-cups \
+    hplip \
+    ImageMagick \
+    ImageMagick-libs \
     kcharselect \
     kdebugsettings \
     kde-connect \
+    kdeconnectd \
+    kde-connect-libs \
     khelpcenter \
     kinfocenter \
-    konsole \
     kwrite \
-    plasma-systemmonitor \
-    akonadi-server \
-    akonadi-server-mysql \
-    colord-kde \
-    plasma-print-manager \
-    plasma-workspace-wallpapers \
-    plasma-desktop-doc \
-    phonon-qt6-backend-vlc \
-    vlc-libs \
-    vlc-plugins-base \
-    vlc-plugin-pulseaudio \
-    vlc-plugin-gstreamer \
+    langpacks-en \
+    langpacks-fonts-en \
+    libcupsfilters \
+    libgs \
+    libppd \
     phonon-backend-vlc-common \
-    google-droid-sans-fonts \
-    google-noto-serif-fonts \
-    google-noto-sans-mono-vf-fonts \
-    google-noto-serif-vf-fonts
+    phonon-qt6-backend-vlc \
+    plasma-desktop-doc \
+    plasma-print-manager \
+    plasma-print-manager-libs \
+    plasma-systemmonitor \
+    plasma-workspace-wallpapers \
+    printer-driver-brlaser \
+    ptouch-driver \
+    splix \
+    vlc-libs \
+    vlc-plugin-ffmpeg \
+    vlc-plugin-gstreamer \
+    vlc-plugin-pipewire \
+    vlc-plugin-pulseaudio \
+    vlc-plugins-base \
+    vlc-plugins-video-out

--- a/desktops/tty/build
+++ b/desktops/tty/build
@@ -2,6 +2,6 @@
 
 set -uexo pipefail
 
-dnf -y remove \
+rpm-ostree override remove \
     firefox \
     firefox-langpacks


### PR DESCRIPTION
Fixes the issue with these packages being marked as "inactive request" when layering them manually

Had to use a full list of packages + dependent packages + dependencies for it to work