### PR TITLE
Improvements to pulling & fix images workflow

### DIFF
--- a/.github/workflows/helper-build-container.yml
+++ b/.github/workflows/helper-build-container.yml
@@ -80,7 +80,17 @@ jobs:
       - name: Pull
         id: pull
         run: |
-          just pull
+          # retry 3 times
+          n=0
+          until [ "$n" -ge 3 ]; do
+            just pull && break
+            n=$((n+1))
+            sleep 10
+          done
+
+          if [ "$n" -ge 3 ]; then
+             exit 1
+          fi
 
       - name: Build
         id: build

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -74,7 +74,7 @@ jobs:
 
   images:
     needs: desktops
-    runs-on: ubuntu-26.04-arm
+    runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:

--- a/tools/containers.just
+++ b/tools/containers.just
@@ -1,6 +1,13 @@
-pull:
+[private]
+pull-base:
     sudo podman pull {{base}}
-    # sudo podman pull {{full_image}} || true
+
+[private]
+pull-image:
+    sudo podman pull {{full_image}} || true
+
+[parallel]
+pull: pull-base pull-image
 
 build *ARGS:
     sudo buildah bud \


### PR DESCRIPTION
1. Retry `just pull` 3 times, should fix the annoying random failures of container builds
2. Parallelize pulls in `containers.just`, makes them faster
3. Build disk images on Ubuntu 24.04, 26.04 is still broken

Related to https://github.com/pocketblue/actions/pull/20