### PR TITLE
Add an option to use chunkah

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,7 +13,7 @@ COPY desktops /desktops
 
 # Building the image
 
-FROM $base
+FROM $base as builder
 
 ARG device
 ARG desktop

--- a/Containerfile.chunkah.in
+++ b/Containerfile.chunkah.in
@@ -1,0 +1,14 @@
+#include "Containerfile"
+
+FROM quay.io/coreos/chunkah AS chunkah
+ARG CHUNKAH_CONFIG_STR
+RUN --mount=from=builder,src=/,target=/chunkah,ro \
+    --mount=type=bind,target=/run/src,rw \
+    chunkah build \
+        --prune /sysroot/ \
+        --label ostree.commit- \
+        --label ostree.final-diffid- \
+        --max-layers=128 \
+        --output oci:/run/src/out
+
+FROM oci:out

--- a/tools/containers.just
+++ b/tools/containers.just
@@ -32,6 +32,25 @@ rechunk *ARGS:
             --from={{full_image}}{{rechunk_suffix}} \
             --output=containers-storage:{{full_image}}
 
+build-chunkah *ARGS:
+    buildah bud \
+        --layers=true \
+        --skip-unused-stages=false \
+        --arch="{{arch}}" \
+        --build-arg="base={{base}}" \
+        --build-arg="device={{device}}" \
+        --build-arg="desktop={{desktop}}" \
+        --build-arg="target_tag={{tag}}" \
+        --build-arg="CHUNKAH_CONFIG_STR=$(podman inspect {{full_image}})" \
+        -v=$(pwd):/run/src \
+        --security-opt=label=disable \
+        {{ if expires_after != "" { "--label quay.expires-after=" + expires_after } else { "" } }} \
+        {{ARGS}} \
+        -t "{{full_image}}" \
+        -f Containerfile.chunkah.in \
+        "."
+    [ -d out ] && rm -r out/
+
 sign digest:
     cosign sign -y --new-bundle-format=false --key env://SIGNING_KEY "{{registry}}/{{device}}-{{desktop}}@{{digest}}"
 


### PR DESCRIPTION
Add an option to use chunkah for rechunking.

It is invoked right in the Containerfile during the build, doesn't require an intermediary build container, can be used without root and makes my builds consistently 1.5-2x faster.

Until chunkah gains wider adoption, let's only use it for local builds to speed up development and keep using rpm-ostree rechunker for production images.