### PR TITLE
Improve rechunking and add an option to use chunkah on GHA

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -11,6 +11,10 @@ on:
       desktop:
         type: string
         required: false
+      rechunker:
+        type: string
+        required: false
+        default: 'rpm-ostree'
       target_tag_override:
         type: string
         required: false
@@ -51,6 +55,14 @@ on:
           - 'plasma-mobile'
           - 'phosh'
         default: 'all'
+      rechunker:
+        type: choice
+        description: 'rechunker'
+        required: true
+        options:
+          - 'rpm-ostree'
+          - 'chunkah'
+        default: 'rpm-ostree'
       target_tag_override:
         type: string
         description: 'override target tag'
@@ -123,5 +135,6 @@ jobs:
       device: ${{ matrix.device }}
       desktop: ${{ matrix.desktop }}
       tag: ${{ inputs.target_tag_override && inputs.target_tag_override || needs.config.outputs.target_tag }}
+      rechunker: ${{ inputs.rechunker }}
       latest: ${{ needs.config.outputs.latest }}
       expires: ${{ needs.config.outputs.expires }}

--- a/.github/workflows/helper-build-container.yml
+++ b/.github/workflows/helper-build-container.yml
@@ -57,10 +57,12 @@ jobs:
             echo "TARGET_IMAGE_NAME=${{ inputs.device }}-${{ inputs.desktop }}" >> $GITHUB_ENV
           else
             pb_tag="${{ inputs.tag }}-${{ steps.conf.outputs.device_variant }}"
+            fallback_tag="${{ inputs.fedora_branch }}-${{ steps.conf.outputs.device_variant }}"
             target_image_name="${{ steps.conf.outputs.device_base }}-${{ inputs.desktop }}"
 
             echo "PB_TAG=$pb_tag" >> $GITHUB_ENV
             echo "PB_FULL_IMAGE=${INPUT_REGISTRY,,}/${target_image_name}:${pb_tag}" >> $GITHUB_ENV
+            echo "PB_FALLBACK_IMAGE=${INPUT_REGISTRY,,}/${target_image_name}:${fallback_tag}" >> $GITHUB_ENV
             echo "TARGET_IMAGE_NAME=$target_image_name" >> $GITHUB_ENV
           fi
 
@@ -79,18 +81,7 @@ jobs:
 
       - name: Pull
         id: pull
-        run: |
-          # retry 3 times
-          n=0
-          until [ "$n" -ge 3 ]; do
-            just pull && break
-            n=$((n+1))
-            sleep 10
-          done
-
-          if [ "$n" -ge 3 ]; then
-             exit 1
-          fi
+        run: just pull
 
       - name: Build
         id: build
@@ -98,8 +89,7 @@ jobs:
 
       - name: Rechunk
         id: rechunk
-        run: |
-          just rechunk
+        run: just rechunk
 
       - name: Push
         id: push

--- a/.github/workflows/helper-build-container.yml
+++ b/.github/workflows/helper-build-container.yml
@@ -53,20 +53,20 @@ jobs:
           echo "REGISTRY_USERNAME=${REGISTRY_USERNAME,,}" >> ${GITHUB_ENV}
 
           if [ -z "${{ steps.conf.outputs.device_variant }}" ]; then
-            echo "PB_TAG=${{ inputs.tag }}" >> $GITHUB_ENV
+            echo "PB_TAG=${{ inputs.tag }}" >> .env
             echo "TARGET_IMAGE_NAME=${{ inputs.device }}-${{ inputs.desktop }}" >> $GITHUB_ENV
           else
             pb_tag="${{ inputs.tag }}-${{ steps.conf.outputs.device_variant }}"
             fallback_tag="${{ inputs.fedora_branch }}-${{ steps.conf.outputs.device_variant }}"
             target_image_name="${{ steps.conf.outputs.device_base }}-${{ inputs.desktop }}"
 
-            echo "PB_TAG=$pb_tag" >> $GITHUB_ENV
-            echo "PB_FULL_IMAGE=${INPUT_REGISTRY,,}/${target_image_name}:${pb_tag}" >> $GITHUB_ENV
-            echo "PB_FALLBACK_IMAGE=${INPUT_REGISTRY,,}/${target_image_name}:${fallback_tag}" >> $GITHUB_ENV
+            echo "PB_TAG=$pb_tag" >> .env
+            echo "PB_FULL_IMAGE=${INPUT_REGISTRY,,}/${target_image_name}:${pb_tag}" >> .env
+            echo "PB_FALLBACK_IMAGE=${INPUT_REGISTRY,,}/${target_image_name}:${fallback_tag}" >> .env
             echo "TARGET_IMAGE_NAME=$target_image_name" >> $GITHUB_ENV
           fi
 
-          cat >> ${GITHUB_ENV} << EOF
+          cat >> .env << EOF
           PB_BRANCH=${{ inputs.fedora_branch }}
           PB_DEVICE=${{ inputs.device }}
           PB_DESKTOP=${{ inputs.desktop }}
@@ -75,21 +75,20 @@ jobs:
           PB_RECHUNK_SUFFIX=-build
           EOF
 
+          cat .env >> $GITHUB_ENV
+
       - uses: extractions/setup-just@v4
         with:
           just-version: '1.46.0'
 
       - name: Pull
-        id: pull
-        run: just pull
+        run: sudo --preserve-env=PATH $(which just) pull
 
       - name: Build
-        id: build
-        run: just build
+        run: sudo --preserve-env=PATH $(which just) build
 
       - name: Rechunk
-        id: rechunk
-        run: just rechunk
+        run: sudo --preserve-env=PATH $(which just) rechunk
 
       - name: Push
         id: push

--- a/.github/workflows/helper-build-container.yml
+++ b/.github/workflows/helper-build-container.yml
@@ -29,6 +29,10 @@ on:
         required: false
         type: string
         default: ''
+      rechunker:
+        required: false
+        type: string
+        default: 'rpm-ostree'
 
 jobs:
   build:
@@ -85,10 +89,16 @@ jobs:
         run: sudo --preserve-env=PATH $(which just) pull
 
       - name: Build
+        if: ${{ inputs.rechunker == 'rpm-ostree' }}
         run: sudo --preserve-env=PATH $(which just) build
 
       - name: Rechunk
+        if: ${{ inputs.rechunker == 'rpm-ostree' }}
         run: sudo --preserve-env=PATH $(which just) rechunk
+
+      - name: Build & rechunk
+        if: ${{ inputs.rechunker == 'chunkah' }}
+        run: sudo --preserve-env=PATH $(which just) build-chunkah
 
       - name: Push
         id: push

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -129,11 +129,11 @@ jobs:
 
       - name: Build disk image
         run: |
-          just disk
+          sudo $(which just) disk
 
       - name: Post-process images
         run: |
-          just postprocess
+          sudo $(which just) postprocess
           if [ -d images ]; then
             sudo chown "$(id -u):$(id -g)" -R images
           fi

--- a/Justfile
+++ b/Justfile
@@ -28,6 +28,7 @@ base := env("PB_BASE",
 
 registry := env("PB_REGISTRY", "localhost")
 
+fallback_image := env("PB_FALLBACK_IMAGE", registry / device + "-" + desktop + ":" + branch)
 full_image := env("PB_FULL_IMAGE", registry / device + "-" + desktop + ":" + tag)
 
 expires_after := env("PB_EXPIRES_AFTER", "")

--- a/tools/containers.just
+++ b/tools/containers.just
@@ -1,13 +1,35 @@
 [private]
-pull-base:
-    sudo podman pull {{base}}
+pull-image image:
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+
+    # retry 3 times
+    n=0
+    until [ "$n" -ge 3 ]; do
+      sudo podman pull {{image}} && break
+      n=$((n+1))
+      sleep 10
+    done
+
+    if [ "$n" -ge 3 ]; then
+       exit 1
+    fi
 
 [private]
-pull-image:
-    sudo podman pull {{full_image}} || true
+pull-pocketblue:
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+
+    if skopeo inspect docker://{{full_image}} >/dev/null 2>&1; then
+        just pull-image {{full_image}}
+    else
+        # to rechunk new branches correctly
+        just pull-image {{fallback_image}}
+        sudo podman tag {{fallback_image}} {{full_image}}
+    fi
 
 [parallel]
-pull: pull-base pull-image
+pull: (pull-image base) pull-pocketblue
 
 build *ARGS:
     sudo buildah bud \

--- a/tools/containers.just
+++ b/tools/containers.just
@@ -6,7 +6,7 @@ pull-image image:
     # retry 3 times
     n=0
     until [ "$n" -ge 3 ]; do
-      sudo podman pull {{image}} && break
+      podman pull {{image}} && break
       n=$((n+1))
       sleep 10
     done
@@ -25,14 +25,14 @@ pull-pocketblue:
     else
         # to rechunk new branches correctly
         just pull-image {{fallback_image}}
-        sudo podman tag {{fallback_image}} {{full_image}}
+        podman tag {{fallback_image}} {{full_image}}
     fi
 
 [parallel]
 pull: (pull-image base) pull-pocketblue
 
 build *ARGS:
-    sudo buildah bud \
+    buildah bud \
         --layers=true \
         --arch="{{arch}}" \
         --build-arg="base={{base}}" \
@@ -45,7 +45,7 @@ build *ARGS:
         "."
 
 rechunk *ARGS:
-    sudo podman run --rm --privileged -v /var/lib/containers:/var/lib/containers {{ARGS}} \
+    podman run --rm --privileged -v /var/lib/containers:/var/lib/containers {{ARGS}} \
         {{base}} \
         rpm-ostree experimental compose build-chunked-oci \
             --bootc \
@@ -77,10 +77,10 @@ sign digest:
     cosign sign -y --new-bundle-format=false --key env://SIGNING_KEY "{{registry}}/{{device}}-{{desktop}}@{{digest}}"
 
 rebase:
-    sudo rpm-ostree rebase ostree-unverified-image:containers-storage:{{full_image}}
+    rpm-ostree rebase ostree-unverified-image:containers-storage:{{full_image}}
 
 bootc *ARGS:
-    sudo podman run \
+    podman run \
         --rm --privileged --pid=host \
         -it \
         -v /sys/fs/selinux:/sys/fs/selinux \

--- a/tools/disk_images.just
+++ b/tools/disk_images.just
@@ -1,6 +1,6 @@
 disk:
-    sudo mkdir -p {{bib_output}}
-    sudo podman run \
+    mkdir -p {{bib_output}}
+    podman run \
         --rm -it --privileged \
         --security-opt label=type:unconfined_t \
         -v {{bib_config}}:/config.toml:ro \
@@ -31,7 +31,7 @@ postprocess:
     export BUILD_AUX=build-aux
     export OCI_IMAGE="{{full_image}}"
 
-    sudo -E tools/postprocess/postprocess.sh
+    tools/postprocess/postprocess.sh
 
 artifacts:
     #!/usr/bin/env bash


### PR DESCRIPTION
1. Pull the base Pocketblue tag (e.g. `44`) when building on new branches for the first time. Optimizes rechunked layers for rpm-ostree & chunkah, and is required for chunkah to work
2. Move sudo out of Justfile. Allows running some targets rootlessly and allows using run0/doas/etc instead of sudo
3. Optional chunkah on GHA - it's faster