### PR TITLE
Optimize containerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 output/
 cosign.key
+.env

--- a/Containerfile
+++ b/Containerfile
@@ -30,15 +30,15 @@ RUN --mount=type=bind,from=common,source=/,target=/ctx/common \
     /ctx/common/cleanup
 
 RUN --mount=type=bind,from=common,source=/,target=/ctx/common \
-    --mount=type=bind,from=devices,source=/,target=/ctx/devices \
-    --mount=type=cache,target=/var/cache \
-    env --chdir=/ctx/devices/${device} ./build && \
-    /ctx/common/cleanup
-
-RUN --mount=type=bind,from=common,source=/,target=/ctx/common \
     --mount=type=bind,from=desktops,source=/,target=/ctx/desktops \
     --mount=type=cache,target=/var/cache \
     env --chdir=/ctx/desktops/${desktop} ./build && \
+    /ctx/common/cleanup
+
+RUN --mount=type=bind,from=common,source=/,target=/ctx/common \
+    --mount=type=bind,from=devices,source=/,target=/ctx/devices \
+    --mount=type=cache,target=/var/cache \
+    env --chdir=/ctx/devices/${device} ./build && \
     /ctx/common/cleanup
 
 # os-release file

--- a/Containerfile
+++ b/Containerfile
@@ -5,11 +5,14 @@ ARG target_tag
 
 # Context
 
-FROM scratch AS ctx
+FROM scratch AS common
+COPY common /
 
-COPY common /common
-COPY devices /devices
-COPY desktops /desktops
+FROM scratch AS devices
+COPY devices /
+
+FROM scratch AS desktops
+COPY desktops /
 
 # Building the image
 
@@ -21,19 +24,19 @@ ARG target_tag
 
 COPY cosign.pub /etc/pki/containers/pocketblue.pub
 
-RUN --mount=type=bind,from=ctx,source=/common,target=/ctx/common \
+RUN --mount=type=bind,from=common,source=/,target=/ctx/common \
     --mount=type=cache,target=/var/cache \
     env --chdir=/ctx/common ./build && \
     /ctx/common/cleanup
 
-RUN --mount=type=bind,from=ctx,source=/common,target=/ctx/common \
-    --mount=type=bind,from=ctx,source=/devices,target=/ctx/devices \
+RUN --mount=type=bind,from=common,source=/,target=/ctx/common \
+    --mount=type=bind,from=devices,source=/,target=/ctx/devices \
     --mount=type=cache,target=/var/cache \
     env --chdir=/ctx/devices/${device} ./build && \
     /ctx/common/cleanup
 
-RUN --mount=type=bind,from=ctx,source=/common,target=/ctx/common \
-    --mount=type=bind,from=ctx,source=/desktops,target=/ctx/desktops \
+RUN --mount=type=bind,from=common,source=/,target=/ctx/common \
+    --mount=type=bind,from=desktops,source=/,target=/ctx/desktops \
     --mount=type=cache,target=/var/cache \
     env --chdir=/ctx/desktops/${desktop} ./build && \
     /ctx/common/cleanup
@@ -41,7 +44,7 @@ RUN --mount=type=bind,from=ctx,source=/common,target=/ctx/common \
 # os-release file
 RUN sed -i "s/^PRETTY_NAME=.*/PRETTY_NAME=\"Fedora Linux ${target_tag} (${desktop})\"/" /usr/lib/os-release
 
-RUN --mount=type=bind,from=ctx,source=/common,target=/ctx/common \
+RUN --mount=type=bind,from=common,source=/,target=/ctx/common \
     /ctx/common/cleanup && \
     /ctx/common/finalize
 

--- a/common/cleanup
+++ b/common/cleanup
@@ -7,5 +7,3 @@ rm -rf /var/lib/dnf || true
 rm -rf /var/log/dnf5.log || true
 rm -rf /boot/* || true
 rm -rf /boot/.* || true
-
-ostree container commit

--- a/common/finalize
+++ b/common/finalize
@@ -8,5 +8,3 @@ find /var/* -maxdepth 0 -type d \! -name cache -exec rm -fr {} \;
 
 mkdir -p /var/tmp
 chmod -R 1777 /var/tmp
-
-ostree container commit


### PR DESCRIPTION
1. Split the build context into different layers (common, devices, desktops). Now changes in one context don't automatically invalidate caches for all layers that use other contexts
2. Move the `desktops` layer above the `devices` layer for more efficient layer caching, because we change device build scripts more often than desktop build scripts
3. Remove `ostree container commit`. Apparently not needed and is replaced by `bootc container lint`