### PR TITLE
nothing-spacewar: keep alsa-utils

### DIFF
--- a/devices/nothing-spacewar/build
+++ b/devices/nothing-spacewar/build
@@ -6,7 +6,6 @@ cp -arfT files/etc /etc
 cp -arfT files/usr /usr
 
 # packages
-dnf -y remove alsa-ucm # conflicts with alsa-ucm-conf-qcom-sc7280
 dnf -y install \
     nothing-spacewar-firmware \
     alsa-ucm-conf-qcom-sc7280 \


### PR DESCRIPTION
`alsa-ucm-conf-qcom-sc7280` used to ship a copy of the whole `ucm2` tree, so it conflicted with `alsa-ucm` and we removed that first. `alsa-utils` requires `alsa-ucm`, so it went with it.

pocketblue/packages#47 makes the package ship only the device configuration and require `alsa-ucm` instead, so there is nothing left to remove. Dropping the line brings `alsa-utils` (amixer, aplay, alsactl) back.

Needs packages#47 merged and `alsa-ucm-conf-qcom-sc7280` rebuilt in the sc7280 copr first, otherwise the install hits the old file conflicts.

Assisted-by: Claude Fable 5