### PR TITLE
common: declare btrfs as the root filesystem for bootc

### DIFF
--- a/common/files/usr/lib/bootc/install/50-pocketblue.toml
+++ b/common/files/usr/lib/bootc/install/50-pocketblue.toml
@@ -1,0 +1,5 @@
+# image-builder asks the container what root filesystem to use. The rawhide
+# base does not answer, so builds fail with "missing required info:
+# DefaultRootFs". Every device's disk.yaml uses btrfs, so declare it here.
+[install.filesystem.root]
+type = "btrfs"


### PR DESCRIPTION
image-builder asks the container which root filesystem to use. The rawhide base does not answer, so image builds on rawhide fail with:

```
error: failed to initialize bootc distro: missing required info: DefaultRootFs
```

which is why every image build so far has been on f44. Every device's `disk.yaml` already uses btrfs, so declare it once in `common/`.

Verified on rawhide with xiaomi-pipa/tty: the container and the disk image both build, producing `pocketblue-xiaomi-pipa-tty-rawhide-common-bootc-rootfs.7z` ([run](https://github.com/LorbusChris/pocketblue/actions/runs/31932777572)). Without this the same build fails at the image step.

Assisted-by: Claude Fable 5