### PR TITLE
Make flash scripts user-friendlier

### DIFF
--- a/devices/qualcomm-sdm845/flash-scripts/flash.sh
+++ b/devices/qualcomm-sdm845/flash-scripts/flash.sh
@@ -68,5 +68,5 @@ fastboot flash $esp_part images/fedora_esp.raw
 echo ">>> (4/5) Flashing fedora_rootfs.raw into $root_part"
 fastboot flash $root_part images/fedora_rootfs.raw
 
-echo '>>> (5/5) Rebooting (this may take a while, DO NOT DISCONNECT THE DEVICE)'
+echo '>>> (5/5) Writing to disk and rebooting (this may take a while, DO NOT DISCONNECT THE DEVICE)'
 fastboot reboot

--- a/devices/xiaomi-nabu-rodriguezst/flash-scripts/flash.cmd
+++ b/devices/xiaomi-nabu-rodriguezst/flash-scripts/flash.cmd
@@ -1,17 +1,28 @@
-@echo on
+@echo off
 setlocal EnableExtensions EnableDelayedExpansion
 
 where fastboot || (pause & exit)
 
-echo 'waiting for device to appear in fastboot'
+echo ^>^>^> Flashing xiaomi-nabu-rodriguezst
 
+echo ^>^>^> Waiting for device to appear in fastboot...
 fastboot getvar product 2>&1 | findstr /i nabu || (pause & exit)
-fastboot erase dtbo_ab || (pause & exit)
-fastboot flash vbmeta_ab images/vbmeta-disabled.img || (pause & exit)
-fastboot flash   boot_ab images/aloha.img || (pause & exit)
-fastboot flash   rawdump images/fedora_esp.raw || (pause & exit)
-fastboot flash  userdata images/fedora_rootfs.raw || (pause & exit)
 
-echo 'rebooting (this may take a while, DO NOT DISCONNECT THE DEVICE)'
+echo ^>^>^> (1/6) Erasing DTBO
+fastboot erase dtbo_ab || (pause & exit)
+
+echo ^>^>^> (2/6) Disabling verified boot
+fastboot flash vbmeta_ab images/vbmeta-disabled.img || (pause & exit)
+
+echo ^>^>^> (3/6) Flashing Aloha
+fastboot flash boot_ab images/aloha.img || (pause & exit)
+
+echo ^>^>^> (4/6) Flashing fedora_esp.raw into rawdump
+fastboot flash rawdump images/fedora_esp.raw || (pause & exit)
+
+echo ^>^>^> (5/6) Flashing fedora_rootfs.raw into userdata
+fastboot flash userdata images/fedora_rootfs.raw || (pause & exit)
+
+echo ^>^>^> (6/6) Writing to disk and rebooting (this may take a while, DO NOT DISCONNECT THE DEVICE)
 fastboot reboot
 pause

--- a/devices/xiaomi-nabu-rodriguezst/flash-scripts/flash.sh
+++ b/devices/xiaomi-nabu-rodriguezst/flash-scripts/flash.sh
@@ -1,17 +1,28 @@
 #!/usr/bin/env bash
 
-set -uexo pipefail
+set -ueo pipefail
 
 which fastboot
 
-echo 'waiting for device to appear in fastboot'
+echo ">>> Flashing xiaomi-nabu-rodriguezst"
 
+echo '>>> Waiting for device to appear in fastboot...'
 fastboot getvar product 2>&1 | grep nabu
-fastboot erase dtbo_ab
-fastboot flash vbmeta_ab images/vbmeta-disabled.img
-fastboot flash boot_ab   images/aloha.img
-fastboot flash rawdump   images/fedora_esp.raw
-fastboot flash userdata  images/fedora_rootfs.raw
 
-echo 'rebooting (this may take a while, DO NOT DISCONNECT THE DEVICE)'
+echo '>>> (1/6) Erasing DTBO'
+fastboot erase dtbo_ab
+
+echo '>>> (2/6) Disabling verified boot'
+fastboot flash vbmeta_ab images/vbmeta-disabled.img
+
+echo '>>> (3/6) Flashing Aloha'
+fastboot flash boot_ab images/aloha.img
+
+echo ">>> (4/6) Flashing fedora_esp.raw into rawdump"
+fastboot flash rawdump images/fedora_esp.raw
+
+echo ">>> (5/6) Flashing fedora_rootfs.raw into userdata"
+fastboot flash userdata images/fedora_rootfs.raw
+
+echo '>>> (6/6) Writing to disk and rebooting (this may take a while, DO NOT DISCONNECT THE DEVICE)'
 fastboot reboot

--- a/devices/xiaomi-nabu/flash-scripts/flash.cmd
+++ b/devices/xiaomi-nabu/flash-scripts/flash.cmd
@@ -1,17 +1,28 @@
-@echo on
+@echo off
 setlocal EnableExtensions EnableDelayedExpansion
 
 where fastboot || (pause & exit)
 
-echo 'waiting for device to appear in fastboot'
+echo ^>^>^> Flashing xiaomi-nabu
 
+echo ^>^>^> Waiting for device to appear in fastboot...
 fastboot getvar product 2>&1 | findstr /i nabu || (pause & exit)
-fastboot erase dtbo_ab || (pause & exit)
-fastboot flash vbmeta_ab images/vbmeta-disabled.img || (pause & exit)
-fastboot flash   boot_ab images/uboot.img || (pause & exit)
-fastboot flash   rawdump images/fedora_esp.raw || (pause & exit)
-fastboot flash  userdata images/fedora_rootfs.raw || (pause & exit)
 
-echo 'rebooting (this may take a while, DO NOT DISCONNECT THE DEVICE)'
+echo ^>^>^> (1/6) Erasing DTBO
+fastboot erase dtbo_ab || (pause & exit)
+
+echo ^>^>^> (2/6) Disabling verified boot
+fastboot flash vbmeta_ab images/vbmeta-disabled.img || (pause & exit)
+
+echo ^>^>^> (3/6) Flashing U-Boot
+fastboot flash boot_ab images/uboot.img || (pause & exit)
+
+echo ^>^>^> (4/6) Flashing fedora_esp.raw into rawdump
+fastboot flash rawdump images/fedora_esp.raw || (pause & exit)
+
+echo ^>^>^> (5/6) Flashing fedora_rootfs.raw into userdata
+fastboot flash userdata images/fedora_rootfs.raw || (pause & exit)
+
+echo ^>^>^> (6/6) Writing to disk and rebooting (this may take a while, DO NOT DISCONNECT THE DEVICE)
 fastboot reboot
 pause

--- a/devices/xiaomi-nabu/flash-scripts/flash.sh
+++ b/devices/xiaomi-nabu/flash-scripts/flash.sh
@@ -1,17 +1,28 @@
 #!/usr/bin/env bash
 
-set -uexo pipefail
+set -ueo pipefail
 
 which fastboot
 
-echo 'waiting for device to appear in fastboot'
+echo ">>> Flashing xiaomi-nabu"
 
+echo '>>> Waiting for device to appear in fastboot...'
 fastboot getvar product 2>&1 | grep nabu
-fastboot erase dtbo_ab
-fastboot flash vbmeta_ab images/vbmeta-disabled.img
-fastboot flash   boot_ab images/uboot.img
-fastboot flash   rawdump images/fedora_esp.raw
-fastboot flash  userdata images/fedora_rootfs.raw
 
-echo 'rebooting (this may take a while, DO NOT DISCONNECT THE DEVICE)'
+echo '>>> (1/6) Erasing DTBO'
+fastboot erase dtbo_ab
+
+echo '>>> (2/6) Disabling verified boot'
+fastboot flash vbmeta_ab images/vbmeta-disabled.img
+
+echo '>>> (3/6) Flashing U-Boot'
+fastboot flash boot_ab images/uboot.img
+
+echo ">>> (4/6) Flashing fedora_esp.raw into rawdump"
+fastboot flash rawdump images/fedora_esp.raw
+
+echo ">>> (5/6) Flashing fedora_rootfs.raw into userdata"
+fastboot flash userdata images/fedora_rootfs.raw
+
+echo '>>> (6/6) Writing to disk and rebooting (this may take a while, DO NOT DISCONNECT THE DEVICE)'
 fastboot reboot

--- a/devices/xiaomi-pipa/flash-scripts/flash.cmd
+++ b/devices/xiaomi-pipa/flash-scripts/flash.cmd
@@ -1,17 +1,28 @@
-@echo on
+@echo off
 setlocal EnableExtensions EnableDelayedExpansion
 
 where fastboot || (pause & exit)
 
-echo 'waiting for device to appear in fastboot'
+echo ^>^>^> Flashing xiaomi-pipa
 
+echo ^>^>^> Waiting for device to appear in fastboot...
 fastboot getvar product 2>&1 | findstr /i pipa || (pause & exit)
-fastboot erase dtbo_ab || (pause & exit)
-fastboot flash vbmeta_ab images/vbmeta-disabled.img || (pause & exit)
-fastboot flash   boot_ab images/silicium.img || (pause & exit)
-fastboot flash   rawdump images/fedora_esp.raw || (pause & exit)
-fastboot flash  userdata images/fedora_rootfs.raw || (pause & exit)
 
-echo 'rebooting (this may take a while, DO NOT DISCONNECT THE DEVICE)'
+echo ^>^>^> (1/6) Erasing DTBO
+fastboot erase dtbo_ab || (pause & exit)
+
+echo ^>^>^> (2/6) Disabling verified boot
+fastboot flash vbmeta_ab images/vbmeta-disabled.img || (pause & exit)
+
+echo ^>^>^> (3/6) Flashing Silicium
+fastboot flash boot_ab images/silicium.img || (pause & exit)
+
+echo ^>^>^> (4/6) Flashing fedora_esp.raw into rawdump
+fastboot flash rawdump images/fedora_esp.raw || (pause & exit)
+
+echo ^>^>^> (5/6) Flashing fedora_rootfs.raw into userdata
+fastboot flash userdata images/fedora_rootfs.raw || (pause & exit)
+
+echo ^>^>^> (6/6) Writing to disk and rebooting (this may take a while, DO NOT DISCONNECT THE DEVICE)
 fastboot reboot
 pause

--- a/devices/xiaomi-pipa/flash-scripts/flash.sh
+++ b/devices/xiaomi-pipa/flash-scripts/flash.sh
@@ -1,22 +1,28 @@
 #!/usr/bin/env bash
 
-set -uexo pipefail
+set -ueo pipefail
 
 which fastboot
 
-set +x
-echo 'waiting for device to appear in fastboot'
-set -x
+echo ">>> Flashing xiaomi-pipa"
 
+echo '>>> Waiting for device to appear in fastboot...'
 fastboot getvar product 2>&1 | grep pipa
+
+echo '>>> (1/6) Erasing DTBO'
 fastboot erase dtbo_ab
+
+echo '>>> (2/6) Disabling verified boot'
 fastboot flash vbmeta_ab images/vbmeta-disabled.img
-fastboot flash   boot_ab images/silicium.img
-fastboot flash   rawdump images/fedora_esp.raw
-fastboot flash  userdata images/fedora_rootfs.raw
 
-set +x
-echo 'rebooting (this may take a while, DO NOT DISCONNECT THE DEVICE)'
-set -x
+echo '>>> (3/6) Flashing Silicium'
+fastboot flash boot_ab images/silicium.img
 
+echo ">>> (4/6) Flashing fedora_esp.raw into rawdump"
+fastboot flash rawdump images/fedora_esp.raw
+
+echo ">>> (5/6) Flashing fedora_rootfs.raw into userdata"
+fastboot flash userdata images/fedora_rootfs.raw
+
+echo '>>> (6/6) Writing to disk and rebooting (this may take a while, DO NOT DISCONNECT THE DEVICE)'
 fastboot reboot


### PR DESCRIPTION
Make them explain what they do in a human-readable form (rather than just printing raw commands) and highlight the human-readable lines with ">>>". People keep freaking out about long reboots so now it actually says "Writing to disk and rebooting" with a scary looking all-caps warning to not disconnect the device

Also removed quotation marks from all windows cmd scripts because `echo` treats them as a printable symbol