### PR TITLE
Embed container-push action into the workflow

### DIFF
--- a/.github/workflows/helper-build-container.yml
+++ b/.github/workflows/helper-build-container.yml
@@ -40,6 +40,8 @@ jobs:
     runs-on: ubuntu-26.04-arm
     permissions:
       packages: write
+    env:
+      SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
     steps:
       - uses: actions/checkout@v6
 
@@ -101,7 +103,7 @@ jobs:
         run: sudo --preserve-env=PATH $(which just) build-chunkah
 
       - name: Install Cosign
-        if: ${{ secrets.SIGNING_KEY }}
+        if: ${{ env.SIGNING_KEY != '' }}
         uses: sigstore/cosign-installer@v4.1.1
 
       - name: Login to registry
@@ -145,8 +147,6 @@ jobs:
           fi
 
       - name: Sign with cosign
-        if: ${{ secrets.SIGNING_KEY }}
-        env:
-          signing_key: ${{ secrets.SIGNING_KEY }}
+        if: ${{ env.SIGNING_KEY != '' }}
         run: |
-          cosign sign -y --new-bundle-format=false --use-signing-config=false --key env://signing_key "$PB_REGISTRY/$TARGET_IMAGE_NAME@${{ steps.push.outputs.digest }}"
+          cosign sign -y --new-bundle-format=false --use-signing-config=false --key env://SIGNING_KEY "$PB_REGISTRY/$TARGET_IMAGE_NAME@${{ steps.push.outputs.digest }}"

--- a/.github/workflows/helper-build-container.yml
+++ b/.github/workflows/helper-build-container.yml
@@ -134,14 +134,14 @@ jobs:
           }
 
           # HACK: push twice as a workaround to push rechunk annotations
-          push $PB_FULL_IMAGE
-          push $PB_FULL_IMAGE
+          push "$PB_REGISTRY/$TARGET_IMAGE_NAME:$PB_TAG"
+          push "$PB_REGISTRY/$TARGET_IMAGE_NAME:$PB_TAG"
 
           echo "digest=$(< /tmp/digestfile)" | tee "${GITHUB_OUTPUT}"
 
           # create and push the :latest tag
           if [ "${{ inputs.latest }}" == "true" ]; then
-            sudo podman image tag $PB_FULL_IMAGE $PB_REGISTRY/$TARGET_IMAGE_NAME:latest
+            sudo podman image tag $PB_REGISTRY/$TARGET_IMAGE_NAME:$PB_TAG $PB_REGISTRY/$TARGET_IMAGE_NAME:latest
             push $PB_REGISTRY/$TARGET_IMAGE_NAME:latest
             push $PB_REGISTRY/$TARGET_IMAGE_NAME:latest
           fi

--- a/.github/workflows/helper-build-container.yml
+++ b/.github/workflows/helper-build-container.yml
@@ -100,14 +100,65 @@ jobs:
         if: ${{ inputs.rechunker == 'chunkah' }}
         run: sudo --preserve-env=PATH $(which just) build-chunkah
 
-      - name: Push
-        id: push
-        uses: pocketblue/actions/container-push@main
+      - name: Install Cosign
+        if: ${{ secrets.SIGNING_KEY }}
+        uses: sigstore/cosign-installer@v4.1.1
+
+      - name: Login to registry
         env:
-          latest: ${{ inputs.latest }}
           username: ${{ env.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
-          registry: ${{ env.PB_REGISTRY }}
+        run: |
+          sudo podman login --username $username --password $password $PB_REGISTRY
+          echo "$password" | docker login -u $username --password-stdin $PB_REGISTRY # for cosign
+
+      - name: Push to registry
+        id: push
+        run: |
+          # retry 3 times
+          function push {
+            n=0
+            until [ "$n" -ge 3 ]; do
+              sudo podman push --digestfile=/tmp/digestfile $PB_FULL_IMAGE && break
+              n=$((n+1))
+              sleep 10
+            done
+
+            if [ "$n" -ge 3 ]; then
+              exit 1
+            fi
+          }
+
+          # HACK: push twice as a workaround to push rechunk annotations
+          push
+          push
+
+          echo "digest=$(< /tmp/digestfile)" | tee "${GITHUB_OUTPUT}"
+
+      - name: Sign with cosign
+        if: ${{ secrets.SIGNING_KEY }}
+        env:
           signing_key: ${{ secrets.SIGNING_KEY }}
-          name: ${{ env.TARGET_IMAGE_NAME }}
-          tag: ${{ env.PB_TAG }}
+        run: |
+          cosign sign -y --new-bundle-format=false --use-signing-config=false --key env://signing_key "$PB_REGISTRY/$TARGET_IMAGE_NAME@${{ steps.push.outputs.digest }}"
+
+      - name: Push latest
+        if: ${{ inputs.latest }}
+        run: |
+          sudo podman image tag $PB_FULL_IMAGE $PB_REGISTRY/$TARGET_IMAGE_NAME:latest
+
+          function push {
+            n=0
+            until [ "$n" -ge 3 ]; do
+              sudo podman push $PB_REGISTRY/$TARGET_IMAGE_NAME:latest && break
+              n=$((n+1))
+              sleep 10
+            done
+
+            if [ "$n" -ge 3 ]; then
+              exit 1
+            fi
+          }
+
+          push
+          push

--- a/.github/workflows/helper-build-container.yml
+++ b/.github/workflows/helper-build-container.yml
@@ -117,9 +117,11 @@ jobs:
         run: |
           # retry 3 times
           function push {
+            img=$1
+
             n=0
             until [ "$n" -ge 3 ]; do
-              sudo podman push --digestfile=/tmp/digestfile $PB_FULL_IMAGE && break
+              sudo podman push --digestfile=/tmp/digestfile $img && break
               n=$((n+1))
               sleep 10
             done
@@ -130,10 +132,17 @@ jobs:
           }
 
           # HACK: push twice as a workaround to push rechunk annotations
-          push
-          push
+          push $PB_FULL_IMAGE
+          push $PB_FULL_IMAGE
 
           echo "digest=$(< /tmp/digestfile)" | tee "${GITHUB_OUTPUT}"
+
+          # create and push the :latest tag
+          if [ "${{ inputs.latest }}" == "true" ]; then
+            sudo podman image tag $PB_FULL_IMAGE $PB_REGISTRY/$TARGET_IMAGE_NAME:latest
+            push $PB_REGISTRY/$TARGET_IMAGE_NAME:latest
+            push $PB_REGISTRY/$TARGET_IMAGE_NAME:latest
+          fi
 
       - name: Sign with cosign
         if: ${{ secrets.SIGNING_KEY }}
@@ -141,24 +150,3 @@ jobs:
           signing_key: ${{ secrets.SIGNING_KEY }}
         run: |
           cosign sign -y --new-bundle-format=false --use-signing-config=false --key env://signing_key "$PB_REGISTRY/$TARGET_IMAGE_NAME@${{ steps.push.outputs.digest }}"
-
-      - name: Push latest
-        if: ${{ inputs.latest }}
-        run: |
-          sudo podman image tag $PB_FULL_IMAGE $PB_REGISTRY/$TARGET_IMAGE_NAME:latest
-
-          function push {
-            n=0
-            until [ "$n" -ge 3 ]; do
-              sudo podman push $PB_REGISTRY/$TARGET_IMAGE_NAME:latest && break
-              n=$((n+1))
-              sleep 10
-            done
-
-            if [ "$n" -ge 3 ]; then
-              exit 1
-            fi
-          }
-
-          push
-          push


### PR DESCRIPTION
We don't reuse it anywhere else and having it in a separate action was inconvinient

Also combined the `Push to registry` and `Latest` steps

Test run: https://github.com/pocketblue/pocketblue/actions/runs/33204581252