### PR TITLE
just: don't put quotes around `compression_7z`

### DIFF
--- a/tools/disk_images.just
+++ b/tools/disk_images.just
@@ -34,7 +34,7 @@ artifacts:
     set -euo pipefail
 
     export DEVICE_PATH=devices/{{device}}
-    export ARGS_7Z="{{compression_7z}}"
+    export ARGS_7Z={{compression_7z}}
     export SCRIPTS=tools/postprocess
 
     tools/collect-artifacts.sh


### PR DESCRIPTION
quotation marks are supplied via the var itself, just's dotenv-load is picky about where you put them